### PR TITLE
JBTIS-369 - bump version to 1.3.100 for luna build

### DIFF
--- a/features/org.jboss.tools.bpel.feature/feature.xml
+++ b/features/org.jboss.tools.bpel.feature/feature.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<feature id="org.jboss.tools.bpel.feature" label="%featureName" version="1.2.100.qualifier" provider-name="%providerName" plugin="org.eclipse.bpel.ui">
+<feature id="org.jboss.tools.bpel.feature" label="%featureName" version="1.3.100.qualifier" provider-name="%providerName" plugin="org.eclipse.bpel.ui">
 
 	<description>
       %description

--- a/features/org.jboss.tools.bpel.feature/pom.xml
+++ b/features/org.jboss.tools.bpel.feature/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.bpel</groupId>
 		<artifactId>features</artifactId>
-		<version>1.2.100-SNAPSHOT</version>
+		<version>1.3.100-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.bpel.features</groupId>
 	<artifactId>org.jboss.tools.bpel.feature</artifactId> 

--- a/features/org.jboss.tools.bpel.test.feature/feature.xml
+++ b/features/org.jboss.tools.bpel.test.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.jboss.tools.bpel.test.feature"
       label="%featureName"
-      version="1.2.100.qualifier"
+      version="1.3.100.qualifier"
       provider-name="%featureProvider"
       image="eclipse_update_120.jpg">
 

--- a/features/org.jboss.tools.bpel.test.feature/pom.xml
+++ b/features/org.jboss.tools.bpel.test.feature/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.bpel</groupId>
 		<artifactId>features</artifactId>
-		<version>1.2.100-SNAPSHOT</version>
+		<version>1.3.100-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.bpel.features</groupId>
 	<artifactId>org.jboss.tools.bpel.test.feature</artifactId> 

--- a/features/pom.xml
+++ b/features/pom.xml
@@ -4,7 +4,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 	<parent>
 		<groupId>org.jboss.tools</groupId>
 		<artifactId>bpel</artifactId>
-		<version>1.2.100-SNAPSHOT</version>
+		<version>1.3.100-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.bpel</groupId>
 	<artifactId>features</artifactId>

--- a/plugins/org.jboss.tools.bpel.runtimes/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.tools.bpel.runtimes/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.jboss.tools.bpel.runtimes;singleton:=true
-Bundle-Version: 1.2.100.qualifier
+Bundle-Version: 1.3.100.qualifier
 Bundle-Activator: org.jboss.tools.bpel.runtimes.RuntimesPlugin
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.ui,

--- a/plugins/org.jboss.tools.bpel.runtimes/pom.xml
+++ b/plugins/org.jboss.tools.bpel.runtimes/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.bpel</groupId>
 		<artifactId>plugins</artifactId>
-		<version>1.2.100-SNAPSHOT</version>
+		<version>1.3.100-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.bpel.plugins</groupId>
 	<artifactId>org.jboss.tools.bpel.runtimes</artifactId> 

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -4,7 +4,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 	<parent>
 		<groupId>org.jboss.tools</groupId>
 		<artifactId>bpel</artifactId>
-		<version>1.2.100-SNAPSHOT</version>
+		<version>1.3.100-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.bpel</groupId>
 	<artifactId>plugins</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,12 +4,12 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 	<parent>
 		<groupId>org.jboss.tools</groupId>
 		<artifactId>parent</artifactId>
-		<version>4.2.0.Alpha1-SNAPSHOT</version>
+		<version>4.2.1.CR1-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools</groupId>
 	<artifactId>bpel</artifactId>
 	<name>bpel.all</name>
-	<version>1.2.100-SNAPSHOT</version>
+	<version>1.3.100-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	<properties>
  		<tycho.scmUrl>scm:git:https://github.com/jbosstools/jbosstools-bpel.git</tycho.scmUrl>

--- a/site/pom.xml
+++ b/site/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools</groupId>
 		<artifactId>bpel</artifactId>
-		<version>1.2.100-SNAPSHOT</version>
+		<version>1.3.100-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.bpel</groupId>
 	<artifactId>bpel.site</artifactId>

--- a/tests/org.jboss.tools.bpel.ui.test/META-INF/MANIFEST.MF
+++ b/tests/org.jboss.tools.bpel.ui.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: org.jboss.tools.bpel.ui.test
 Bundle-SymbolicName: org.jboss.tools.bpel.ui.test
-Bundle-Version: 1.2.100.qualifier
+Bundle-Version: 1.3.100.qualifier
 Bundle-Activator: org.jboss.tools.bpel.ui.test.Activator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,

--- a/tests/org.jboss.tools.bpel.ui.test/pom.xml
+++ b/tests/org.jboss.tools.bpel.ui.test/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.bpel</groupId>
 		<artifactId>tests</artifactId>
-		<version>1.2.100-SNAPSHOT</version>	
+		<version>1.3.100-SNAPSHOT</version>	
 	</parent>
 	<groupId>org.jboss.tools.bpel.tests</groupId>
 	<artifactId>org.jboss.tools.bpel.ui.test</artifactId> 

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -4,7 +4,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 	<parent>
 		<groupId>org.jboss.tools</groupId>
 		<artifactId>bpel</artifactId>
-		<version>1.2.100-SNAPSHOT</version>
+		<version>1.3.100-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.bpel</groupId>
 	<artifactId>tests</artifactId>


### PR DESCRIPTION
Hey @bbrodt - I bumped the version to 1.3.100 and I'll promote to luna stable.  I'll then build it - the site category.xml will pick up the latest org.eclipse bpel.  I'll then add it to the IS.  wdyt>
